### PR TITLE
fix: replace front dynamo export to torch export

### DIFF
--- a/python/src/infinitensor/converter/registry.py
+++ b/python/src/infinitensor/converter/registry.py
@@ -8,57 +8,60 @@ from torch import fx
 class ConverterRegistry:
 
     def __init__(self):
-        self._module_converters: Dict[torch.nn.Module, Callable[[fx.Node], None]] = {}
-        self._method_converters: Dict[str, Callable[[fx.Node], None]] = {}
+        # { "aten.matmul": { "default": fn, "out": fn, None: fn } }
+        self._method_converters: Dict[str, Dict[Optional[str], Callable]] = {}
 
-    def register_module(self, module_class):
-        """装饰器：注册模块转换器"""
-
-        def decorator(func):
-            self._module_converters[module_class] = func
-            return func
-
-        return decorator
-
-    def register_method(self, method_name: str):
+    def register(self, op_name: str, overload: Optional[str] = None):
         """装饰器：注册方法和函数转换器"""
 
         def decorator(func):
-            self._method_converters[method_name] = func
+            self._method_converters.setdefault(op_name, {})[overload] = func
             return func
 
         return decorator
 
-    def get_module_converter(self, module_class) -> Optional[Callable]:
-        """获取模块转换器"""
-        # 也检查父类
-        if module_class in self._module_converters:
-            return self._module_converters[module_class]
-        return None
-
-    def get_method_converter(self, method_name: str) -> Optional[Callable]:
+    def get_method_converter(self, op_name: str, overload: Optional[str] = None) -> Optional[Callable]:
         """获取方法和函数转换器"""
-        if method_name in self._method_converters:
-            return self._method_converters[method_name]
-        return None
+        if op_name in self._method_converters:
+            table = self._method_converters[op_name]
+            if overload:
+                if overload in table:
+                    return table[overload]
+                else:
+                    raise ValueError(f"Unsupported op.overload : {op_name}_{overload}")
+            else:
+                if None in table:
+                    return table[None]
+                else:
+                    raise ValueError(f"Unsupported op.overload : {op_name}")
+        else:
+            raise ValueError(f"Unsupported op : {op_name}")
+
 
     def update(self, custom_converters: Dict):
-        """更新转换器"""
+        """更新转换器
+        Args:
+            custom_converters:
+            {
+                (op_name, overload): converter
+            }
+        """
         for key, converter in custom_converters.items():
-            if inspect.isclass(key) and issubclass(key, nn.Module):
-                self._module_converters[key] = converter
-            elif isinstance(key, str):
+            if isinstance(key, tuple) and len(key) == 2:
+                op_name, overload = key
+                self._method_converters.setdefault(op_name, {})[overload] = converter
+            if isinstance(key, str):
                 self._method_converters[key] = converter
+            else:
+                raise TypeError(f"Invalid key type: {type(key)}")
 
     def clear(self):
         """清空所有转换器"""
-        self._module_converters.clear()
         self._method_converters.clear()
 
     def list_all_converters(self):
         """列出所有转换器"""
         return {
-            "modules": list(self._module_converters.keys()),
             "methods": list(self._method_converters.keys()),
         }
 

--- a/python/src/infinitensor/converter/unified_converters.py
+++ b/python/src/infinitensor/converter/unified_converters.py
@@ -1,17 +1,9 @@
 import torch.nn as nn
 from .registry import registry
 
+#https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/native_functions.yaml
 
-@registry.register_module(nn.Linear)
-def convert_linear(translator, node, module):
-    x = translator.tensors[node.args[0]]
-    module = translator.named_modules[node.target]
-    weight = translator.params[module.weight]
-    bias = translator.params.get(module.bias, None)
-    translator.tensors[node] = translator.builder.gemm(x, weight, bias, transB=True)
-
-
-@registry.register_method("matmul")
+@registry.register("matmul","default")
 def convert_matmul(translator, node):
     a = translator.tensors[node.args[0]]
     b = translator.tensors[node.args[1]]

--- a/python/src/infinitensor/torch_fx_translator.py
+++ b/python/src/infinitensor/torch_fx_translator.py
@@ -1,11 +1,12 @@
 import ctypes
 import pyinfinitensor
-from pyinfinitensor import GraphBuilder, Tensor, dtype_from_string, Runtime, ShapeExpr
+from pyinfinitensor import GraphBuilder, Tensor, dtype_from_string, Runtime, ShapeExpr, StrideExpr
 import torch
 from torch import fx
-import torch._dynamo as dynamo
+from torch.export import export, Dim
 from typing import Callable, Dict, List, Tuple, Optional, Union
 from .converter import registry
+import inspect
 
 
 class TorchFXTranslator:
@@ -20,9 +21,8 @@ class TorchFXTranslator:
         self.params: Dict[torch.Tensor, Tensor] = {}  # 存储所有参数
         self.outputs: List[Tensor] = []  # 存储输出张量
         self.input_vars: Dict[str, Tensor] = {}
-        self.named_modules = None
         self.symbols = {}  # 符号 -> {'var': 变量名, 'value': 具体值, 'info': 详细信息}
-        self.dynamic_input_infos: List[Tuple[Tuple, str]] = []  # 动态输入信息
+        self.dynamic_input_infos: List[Tuple[Tuple, Tuple, str]] = []  # 动态输入信息(shape, stride, dtype)
         if custom_converters:
             registry.update(custom_converters)
 
@@ -47,6 +47,23 @@ class TorchFXTranslator:
         for symbol_str in self.symbols:
             self.symbols[symbol_str]["value"] = None
 
+    def _add_dynamic_shapes(self, model, input_list):
+        """
+        为每个 Tensor 生成:
+        arg_{i}: {0: Dim.AUTO, 1: Dim.AUTO, ...}
+        """
+        sig = inspect.signature(model.forward)
+        param_names = [p.name for p in sig.parameters.values() if p.name != "self"]
+        assert(len(param_names) == len(input_list))
+        dynamic_shapes = {}
+        for idx, (p, t) in enumerate(zip(param_names, input_list)):
+            if not isinstance(t, torch.Tensor):
+                raise ValueError("input is not torch Tensor")
+            dynamic_shapes[p] = {
+                dim: Dim.AUTO for dim in range(t.dim())
+            }
+        return dynamic_shapes
+
     def _create_input_tensors(
         self, input_list: List[torch.Tensor], is_real_tensor: bool
     ) -> List:
@@ -70,119 +87,64 @@ class TorchFXTranslator:
                 input_tensors.append(tensor)
                 self.input_vars[f"inp_{i}"] = tensor
         else:
-            for i, (shape, dtype) in enumerate(self.dynamic_input_infos):
-                tensor = self.builder.tensor(ShapeExpr(shape), dtype)
+            for i, (shape, stride, dtype) in enumerate(self.dynamic_input_infos):
+                tensor = self.builder.tensor(ShapeExpr(shape), dtype, StrideExpr(stride))
                 input_tensors.append(tensor)
                 self.input_vars[f"inp_{i}"] = tensor
         return input_tensors
 
-    def _extract_fake_tensors(self, graph):
-        """从FX图中提取FakeTensor信息"""
-        fake_inputs = []
-
-        for node in graph.nodes:
-            if node.op != "placeholder":
-                continue
-            if (
-                "grapharg" in node.meta
-                and node.meta["grapharg"].fake_tensor is not None
-            ):
-                fake_tensor = node.meta["grapharg"].fake_tensor
-                fake_inputs.append(fake_tensor)
-            if "val" in node.meta and isinstance(
-                node.meta["val"], torch._subclasses.fake_tensor.FakeTensor
-            ):
-                fake_tensor = node.meta["val"]
-                fake_inputs.append(fake_tensor)
-            # TODO: 由于不同的torch compile方法会导致Node中meta信息不一致，可能需进一步调研，目前是借鉴了tvm现有实现
-
-        return fake_inputs
-
     def _process_dynamic_shapes(self, fake_inputs):
         """处理动态形状"""
-        for i, tensor in enumerate(fake_inputs):
-            shape = []
-            for j, s in enumerate(tensor.shape):
+        for i, tensor in enumerate(fake_inputs.values()):
+            shape = tensor.shape
+            stride = tensor.stride
+            assert(len(shape) == len(stride))
+            tensor_shape = []
+            tensor_stride = []
+            dtype = dtype_from_string(str(tensor.dtype))
+            for j, (dim, st) in enumerate(zip(shape, stride[::-1])):
+                # 处理shape信息
                 if (
                     hasattr(torch, "SymInt")
-                    and isinstance(s, torch.SymInt)
-                    and not str(s).isdigit()
+                    and isinstance(dim, torch.SymInt)
+                    and not str(dim).isdigit()
                 ):
                     # 处理符号维度
-                    sym_str = str(s)
+                    sym_str = str(dim)
                     self._add_symbol(sym_str, i, j)
-                    shape.append(self.symbols[sym_str]["var"])
+                    tensor_shape.append(self.symbols[sym_str]["var"])
                 else:
                     # 具体维度
-                    shape.append(int(s))
+                    tensor_shape.append(int(dim))
+                # 处理stride信息
+                if (
+                    hasattr(torch, "SymInt")
+                    and isinstance(st, torch.SymInt)
+                    and not str(st).isdigit()
+                ):
+                    # 处理符号维度
+                    sym_str = str(st)
+                    assert(self.symbols.get(sym_str))
+                    tensor_stride.insert(0, self.symbols[sym_str]["var"])
+                else:
+                    # 具体维度
+                    tensor_stride.insert(0, int(st))
 
-            dtype = dtype_from_string(str(tensor.dtype))
-            self.dynamic_input_infos.append((shape, dtype))
-
-    def _fetch_attr(self, model, target: str):
-        """获取模型属性"""
-        target_atoms = target.split(".")
-        attr_itr = model
-
-        try:
-            for atom in target_atoms:
-                if not hasattr(attr_itr, atom):
-                    raise RuntimeError(f"Node referenced non-existing target: {target}")
-                attr_itr = getattr(attr_itr, atom)
-            return attr_itr
-        except Exception as e:
-            raise RuntimeError(f"Failed to fetch attribute {target}: {e}")
-
-    def _process_placeholder(self, node, input_tensors):
-        """处理输入占位符节点"""
-        if len(input_tensors) == 0:
-            raise ValueError(
-                f"Provided inputs is less than actual inputs. "
-                f"Node {node.name} requires an input but no more inputs available."
-            )
-        tensor = input_tensors.pop(0)
-        self.nodes_map[node] = tensor
-        self.tensors[node] = tensor
-
-    def _process_get_attr(self, node, fx_module):
-        """处理属性获取节点"""
-        attr_value = self._fetch_attr(fx_module, node.target)
-
-        if isinstance(attr_value, torch.Tensor):
-            # 如果是参数或缓冲区张量
-            if attr_value not in self.params:
-                self.params[attr_value] = self.builder.tensor(
-                    ShapeExpr(attr_value.shape), dtype_from_string(attr_value.dtype)
-                )
-                self.params[attr_value].set_data(attr_value.data_ptr(), self.runtime)
-                self.nodes_map[node] = self.params[attr_value]
-                self.tensors[node] = self.params[attr_value]
-        else:
-            raise ValueError(f"Unsupported attribute type: {type(attr_value)}")
-
-    def _process_call_module(self, node):
-        module = self.named_modules[node.target]
-        module_type = type(module)
-        function = registry.get_module_converter(module_type)
-        if function:
-            try:
-                self.nodes_map[node] = function
-                function(self, node, module)
-            except Exception as e:
-                raise RuntimeError(
-                    f"Converter for {module_type.__name__} failed: {str(e)}"
-                )
-        else:
-            raise ValueError(f"Unsupported module type: {module_type.__name__}")
+            self.dynamic_input_infos.append((tensor_shape, tensor_stride, dtype))
 
     def _process_call_function(self, node):
         """处理函数调用节点"""
-        func_name = (
-            node.target.__name__
-            if hasattr(node.target, "__name__")
-            else str(node.target)
-        )
-        function = registry.get_method_converter(func_name)
+        target = node.target
+        if hasattr(target,"_overloadpacket"):
+            op_name = str(target._overloadpacket).split('.')[-1]
+            overload = target._overloadname
+            function = registry.get_method_converter(op_name, overload)
+        else:
+            if hasattr(target, "__name__"):
+                op_base_name = target.__name__
+            else:
+                op_base_name = str(target)
+            function = registry.get_method_converter(op_base_name)
         if function:
             try:
                 self.nodes_map[node] = function
@@ -191,19 +153,6 @@ class TorchFXTranslator:
                 raise RuntimeError(f"Converter for {func_name} failed: {str(e)}")
         else:
             raise ValueError(f"Unsupported function: {func_name}")
-
-    def _process_call_method(self, node):
-        """处理方法调用节点"""
-        method_name = node.target
-        function = registry.get_method_converter(method_name)
-        if function:
-            try:
-                self.nodes_map[node] = function
-                function(self, node)
-            except Exception as e:
-                raise RuntimeError(f"Converter for {method_name} failed: {str(e)}")
-        else:
-            raise ValueError(f"Unsupported method: {method_name}")
 
     def _process_output(self, node):
         """处理输出节点"""
@@ -241,6 +190,52 @@ class TorchFXTranslator:
         t = t.as_strided(size=shape, stride=stride)
         return t
 
+    def _extract_graph_signature(self):
+        fake_inputs = {}
+        def transform_parameter_string(s):
+            return re.sub(r'_', '.', re.sub(r'^p_', '', s))
+        def transform_buffer_string(s):
+            return re.sub(r'_', '.', re.sub(r'^b_', '', s))
+        nodes = list(self.module.graph_module.graph.nodes)
+        for i, spec in enumerate(self.module.graph_signature.input_specs):
+            kind = spec.kind.name
+            node = nodes[i]
+            name = spec.arg.name
+            if kind == "PARAMETER":
+                assert(node.op == "placeholder" and isinstance(
+                node.meta["val"], torch._subclasses.fake_tensor.FakeTensor
+            ))
+                shape_expr = ShapeExpr(node.meta["tensor_meta"].shape)
+                stride_expr = StrideExpr(node.meta["tensor_meta"].stride)
+                dtype = dtype_from_string(str(node.meta["tensor_meta"].dtype))
+                self.params[name] = self.builder.tensor(shape_expr, dtype, stride_expr)
+                self.params[name].set_data(self.module.state_dict[transform_parameter_string(name)].data_ptr(),self.runtime)
+                self.nodes_map[node] = self.params[name]
+                self.tensors[node] = self.params[name]
+            elif kind == "BUFFER":
+                if len(node.users) == 0:
+                    continue
+                assert(node.op == "placeholder" and isinstance(
+                node.meta["val"], torch._subclasses.fake_tensor.FakeTensor
+            ))
+                shape_expr = ShapeExpr(node.meta["tensor_meta"].shape)
+                stride_expr = StrideExpr(node.meta["tensor_meta"].stride)
+                dtype = dtype_from_string(str(node.meta["tensor_meta"].dtype))
+                self.params[name] = self.builder.tensor(shape_expr, dtype, stride_expr)
+                self.params[name].set_data(self.module.state_dict[transform_buffer_string(name)].data_ptr(),self.runtime)
+                self.nodes_map[node] = self.params[name]
+                self.tensors[node] = self.params[name]
+            elif kind == "USER_INPUT":
+                if "val" in node.meta and isinstance(
+                node.meta["val"], torch._subclasses.fake_tensor.FakeTensor):
+                    fake_tensor = node.meta["tensor_meta"]
+                    fake_inputs[node] = fake_tensor
+            else:
+                raise ValueError(f"Unsupported input kind: {kind}")
+        
+        return fake_inputs
+
+
     def import_from_fx(
         self, model, input_list: List[torch.Tensor], is_real_tensor: bool = False
     ):
@@ -253,39 +248,29 @@ class TorchFXTranslator:
         """
 
         self.builder = GraphBuilder(self.runtime)
-        fx_module = fx.symbolic_trace(model)
+        dynamic_shapes = self._add_dynamic_shapes(model, input_list)
         try:
-            fx_module = dynamo.export(model, *input_list).graph_module
+            self.module = export(model, tuple(input_list), dynamic_shapes=dynamic_shapes)
         except:
             raise RuntimeError("Failed to export the PyTorch model to FX.")
-        self.named_modules = dict(fx_module.named_modules())
 
-        self.module = fx_module.graph
+        # 解析graph_signature，提取params、buffers、inputs、outputs
+        fake_inputs = self._extract_graph_signature()
+
         # 提取符号形状信息
-        fake_inputs = self._extract_fake_tensors(self.module)
         self._process_dynamic_shapes(fake_inputs)
         # 创建输入张量
         inputs = self._create_input_tensors(input_list, is_real_tensor)
-        # 创建params
-        for _, param in fx_module.named_parameters():
-            if isinstance(param, torch.Tensor):
-                self.params[param] = self.builder.tensor(
-                    ShapeExpr(param.shape), dtype_from_string(str(param.dtype))
-                )
-                self.params[param].set_data(param.data_ptr(), self.runtime)
+        for (node, tensor) in zip(fake_inputs.keys(), inputs):
+            self.nodes_map[node] = tensor
+            self.tensors[node] = tensor
 
         # 处理FX图节点
-        for node in self.module.nodes:
+        for node in self.module.graph_module.graph.nodes:
             if node.op == "placeholder":
-                self._process_placeholder(node, inputs)
+                continue
             elif node.op == "call_function":
                 self._process_call_function(node)
-            elif node.op == "call_module":
-                self._process_call_module(node)
-            elif node.op == "call_method":
-                self._process_call_method(node)
-            elif node.op == "get_attr":
-                self._process_get_attr(node, fx_module)
             elif node.op == "output":
                 self._process_output(node)
                 break


### PR DESCRIPTION
由于dynamo export存在issue-9描述的问题，因此替换为torch export
存在以下几点改动：
1. torch export导出的fx图更加底层且对应aten算子，所有的call_method和call_moudle节点均被替换为call_function，因此修改了解析fx图的方案，并修改了对应的注册机制
2. 利用torch export的检查形状机制，在前端中针对输入给定动态形状Dim.AUTO，从而更好地利用torch export检查形状机制，并且保证用户端不感知后端操作，用户侧没有任何变动
3. 由于fx中会将所有的param视为输入，所以对应的fx图中没有了get_attr类似的节点，因此placeholder节点不仅代表模型输入，因此改为解析graph_signature来解决这一问题，graph_signature中会存储所有的输入信息，且会按照类别进行分类